### PR TITLE
fix: correct README simple example to not require labels for non-pinned use

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Simple example:
     title: Hello, world
     body: |-
       :wave: Hi, {{#each assignees}}@{{this}}{{#unless @last}}, {{/unless}}{{/each}}!
+# ...
+```
+
+Example with pinning (note: `pinned` requires `labels`):
+```yml
+# ...
+- name: Create new issue
+  uses: imjohnbo/issue-bot@v3
+  with:
+    assignees: "octocat, monalisa"
+    labels: "standup"
+    title: Hello, world
+    body: |-
+      :wave: Hi, {{#each assignees}}@{{this}}{{#unless @last}}, {{/unless}}{{/each}}!
     pinned: true
 # ...
 ```


### PR DESCRIPTION
The simple usage example included `pinned: true` without `labels`, which causes "Error: Invalid inputs" for anyone copying it verbatim. Pinning requires labels to find the previous issue to unpin. Split into a plain example and a separate pinning example with the required `labels` field.

Closes #104